### PR TITLE
Update icons search path

### DIFF
--- a/AppImageBuilder/app_dir/metadata/icon_bundler.py
+++ b/AppImageBuilder/app_dir/metadata/icon_bundler.py
@@ -38,7 +38,9 @@ class IconBundler:
 
     def _get_icon_path(self):
         search_paths = [os.path.join(self.app_dir, 'usr', 'share', 'icons'),
-                        os.path.join('/', 'usr', 'share', 'icons')]
+                        os.path.join(self.app_dir, 'usr', 'share', 'pixmaps'),
+                        os.path.join('/', 'usr', 'share', 'icons'),
+                        os.path.join('/', 'usr', 'share', 'pixmaps')]
 
         for path in search_paths:
             path = self._search_icon(path)


### PR DESCRIPTION
According to [FDO icon spec](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html#directory_layout),

> Icons and themes are looked for in a set of directories. By default, apps should look in $HOME/.icons (for backwards compatibility), in $XDG_DATA_DIRS/icons and in /usr/share/pixmaps (in that order).