### PR TITLE
Pacman fixes

### DIFF
--- a/appimagebuilder/app_dir/deploy/pacman/venv.py
+++ b/appimagebuilder/app_dir/deploy/pacman/venv.py
@@ -130,7 +130,6 @@ class Venv:
             "--print-format '%%l' " \
             "--noconfirm {exclude} {packages}"
         self._logger.debug(command)
-        print(exclude_str, packages_str)
         output = self._run_command(command,
                                    packages=packages_str,
                                    exclude=exclude_str,

--- a/appimagebuilder/app_dir/deploy/pacman/venv.py
+++ b/appimagebuilder/app_dir/deploy/pacman/venv.py
@@ -122,7 +122,7 @@ class Venv:
         output = self._run_command(command, packages=packages_str,
                                    stdout=subprocess.PIPE)  # noqa:
 
-        return output.stdout.decode("utf-8").splitlines()  # noqa:
+        return output.stdout.read().decode("utf-8").splitlines()  # noqa:
 
     def _run_pacman_list_package_files(self, exclude_str, packages_str):
         command = \
@@ -151,7 +151,7 @@ class Venv:
             stdout=subprocess.PIPE  # noqa:
         )
 
-        lines = output.stdout.decode("utf-8").splitlines()  # noqa:
+        lines = output.stdout.read().decode("utf-8").splitlines()  # noqa:
         if lines:
             first_line = lines[0]
             line_parts = first_line.split(" ")

--- a/appimagebuilder/app_dir/deploy/pacman/venv.py
+++ b/appimagebuilder/app_dir/deploy/pacman/venv.py
@@ -128,17 +128,14 @@ class Venv:
         command = \
             "{pacman} --config {config} -S " \
             "--print-format '%%l' " \
-            "--noconfirm {exclude} {packages}".format(
-                pacman=self._deps["pacman"],
-                config=self._config_path,
-                exclude=exclude_str,
-                packages=packages_str,
-            )
+            "--noconfirm {exclude} {packages}"
         self._logger.debug(command)
-        output = subprocess.run(command, stdout=subprocess.PIPE)
-        self._assert_successful_output(output)
-
-        files = re.findall("file://(.*)", output.stdout.decode("utf-8"))
+        print(exclude_str, packages_str)
+        output = self._run_command(command,
+                                   packages=packages_str,
+                                   exclude=exclude_str,
+                                   stdout=subprocess.PIPE)  # noqa:
+        files = re.findall("file://(.*)", output.stdout.read().decode("utf-8"))
         return files
 
     @staticmethod

--- a/appimagebuilder/app_dir/deploy/pacman/venv.py
+++ b/appimagebuilder/app_dir/deploy/pacman/venv.py
@@ -186,8 +186,8 @@ class Venv:
                         f.write("Server = %s\n" % server)
 
     def _configure_keyring(self):
-        self._run_command("{fakeroot} {pacman_key} --config {config} --init")
-        self._run_command("{fakeroot} pacman-key --config {config} --populate archlinux")
+        self._run_command("{fakeroot} {pacman-key} --config {config} --init")
+        self._run_command("{fakeroot} {pacman-key} --config {config} --populate archlinux")
 
     def _run_command(self, command,
                      stdout=sys.stdout,

--- a/appimagebuilder/app_dir/deploy/pacman/venv.py
+++ b/appimagebuilder/app_dir/deploy/pacman/venv.py
@@ -24,6 +24,14 @@ class PacmanVenvError(RuntimeError):
     pass
 
 
+def check_if_sudo_required():
+    if os.getuid() == 0:
+        # the user is root, we do not want to use sudo
+        return ''
+    # return the path to sudo, else return ''
+    return shutil.which("sudo") or ''
+
+
 class Venv:
     default_options = []
 
@@ -42,6 +50,7 @@ class Venv:
         self._repositories = repositories
         self._architecture = architecture
         self._options = user_options
+        self._needs_sudo = check_if_sudo_required()
 
         self._db_path.mkdir(parents=True, exist_ok=True)
         self._cache_dir.mkdir(parents=True, exist_ok=True)

--- a/appimagebuilder/app_dir/deploy/pacman/venv.py
+++ b/appimagebuilder/app_dir/deploy/pacman/venv.py
@@ -117,7 +117,7 @@ class Venv:
     def _run_pacman_list_packages_and_versions(self, packages_str):
         command = \
             "{pacman} --config {config} -S " \
-            "--print-format '%%n=%%v' " \
+            "--print-format '%n=%v' " \
             "--noconfirm {packages}"
         output = self._run_command(command, packages=packages_str,
                                    stdout=subprocess.PIPE)  # noqa:

--- a/appimagebuilder/app_dir/runtime/helpers/gdk_pixbuf.py
+++ b/appimagebuilder/app_dir/runtime/helpers/gdk_pixbuf.py
@@ -12,6 +12,7 @@
 import logging
 import os
 import subprocess
+import shutil
 
 from .base_helper import BaseHelper
 
@@ -55,6 +56,13 @@ class GdkPixbuf(BaseHelper):
         for root, dirs, files in os.walk("/usr/lib"):
             if "gdk-pixbuf-query-loaders" in files:
                 return os.path.join(root, "gdk-pixbuf-query-loaders")
+        # we did not find gdk-pixbuf-query-loaders in /usr/lib
+        # perhaps we should search /usr/bin too
+        # Arch Linux has gdk-pixbuf-query-loaders in /usr/bin and 
+        # not in /usr/lib. This can be easily found out using 
+        # shutil.which API. => $PATH
+        if shutil.which("gdk-pixbuf-query-loaders"):
+            return shutil.which("gdk-pixbuf-query-loaders")
         raise RuntimeError("Missing 'gdk-pixbuf-query-loaders' executable")
 
     def _get_gdk_pixbuf_loaders_path(self):


### PR DESCRIPTION
`pacman` required some functions to be run as `sudo` or root. It is not required for all options. Failure to run as root, gives a weird error which is ambiguous, or not clear enough to make out why it failed. Running it with `sudo` on non-root user would be particularly helpful.


### Changelog
* feat: check for deps before continuing …
77fea9d
It might be good to make sure that all the deps are installed before proceeding. In the pacman module, we use pacman, pacman-key and bsdtar. So we need to check if its available on the host system

* feat: add a helper function `check_if_sudo_required` …
9d50ea2
check if sudo is required. When appimage-builder is not being run as root, for certain functions, we need to use sudo,
running the entire appimage-builder is not something safe. So it might be good to check
  - (i) if the user running appimage-builder is root, for example on docker containers
  - (ii) if the user is not root, get the path to sudo, and run it as sudo. This will prompt for a password


* fix: so not use shell=True, and optimize subprocess performance …
891b878
using shell=True, is not suggested. If we know the real path to pacman and provide it the arguments, its a bit more safer and trusted subprocess method.
Along with that, a new function _run_command which can easily format the commands with
  - (i) the absolute path of pacman
  - (ii) absolute path of sudo, if necessary
  - (iii) provide the config path only once, i.e do not need to provide it repeatedly, which reduces code duplication
  - (iv) redirect stderr to stderr, when we are not doing anything useful
anyway 
  - (v) log the command run to `logger`
  - (vi) optionally raise error if the return code was not 0
  - (vii) redirect the stdout of the subprocess to sys.stdout if we are not doing any processing with it
(This fixes a bug in appimage-builder which causes it to hang on slow
download speeds despite pacman completed downloading)

