### PR TITLE
feat: ask user for updateinformation, but fallback to guess

### DIFF
--- a/appimagebuilder/appimage.py
+++ b/appimagebuilder/appimage.py
@@ -23,8 +23,16 @@ class AppImageCreator:
         self.app_name = recipe.get_item("AppDir/app_info/name")
         self.app_version = recipe.get_item("AppDir/app_info/version")
         self.update_information = recipe.get_item("AppImage/update-information", "None")
+        self.guess_update_information = False
+
         if self.update_information == "None":
             self.update_information = None
+        elif self.update_information == "guess":
+            # appimagetool supports a param --guess, -g
+            # this automatically generates the update_information based on CI
+            # variables, perhaps, we should use that
+            self.update_information = None
+            self.guess_update_information = True
 
         self.sing_key = recipe.get_item("AppImage/sign-key", "None")
         if self.sing_key == "None":
@@ -49,6 +57,7 @@ class AppImageCreator:
         appimage_tool = AppImageToolCommand(self.app_dir, self.target_file)
         appimage_tool.target_arch = self.target_arch
         appimage_tool.update_information = self.update_information
+        appimage_tool.guess_update_information = self.guess_update_information
         appimage_tool.sign_key = self.sing_key
         appimage_tool.runtime_file = runtime_path
         appimage_tool.run()

--- a/appimagebuilder/commands/appimagetool.py
+++ b/appimagebuilder/commands/appimagetool.py
@@ -24,6 +24,7 @@ class AppImageToolCommand(Command):
         self.app_dir = app_dir
         self.runtime_file = None
         self.update_information = None
+        self.guess_update_information = False
         self.sign_key = None
         self.target_file = target_file
         self.target_arch = None
@@ -51,6 +52,9 @@ class AppImageToolCommand(Command):
 
         if self.update_information:
             command.extend(["--updateinformation", self.update_information])
+
+        if self.guess_update_information:
+            command.extend(["--guess"])
 
         command.extend([self.app_dir, self.target_file])
         return command

--- a/appimagebuilder/generator/generator.py
+++ b/appimagebuilder/generator/generator.py
@@ -43,6 +43,7 @@ class RecipeGenerator:
         self.runtime_generator = None
         self.runtime_env = None
         self.appimage_arch = None
+        self.appimage_update_information = "guess"
 
         self.apt_arch = None
         self.apt_includes = None
@@ -122,6 +123,9 @@ class RecipeGenerator:
         self.app_info_exec_args = questionary.text(
             "Arguments [Default: $@] :", default=self.app_info_exec_args
         ).ask()
+        self.appimage_update_information = questionary.text(
+            "Update Information [Default: guess] :", default="guess"
+        ).ask()
         self.apt_arch = questionary.select(
             "Architecture :", ["amd64", "arm64", "i386", "armhf"], default=self.apt_arch
         ).ask()
@@ -153,6 +157,7 @@ class RecipeGenerator:
                 "files_includes": self.files_include,
                 "files_excludes": self.files_exclude,
                 "appimage_arch": self.appimage_arch,
+                "appimage_update_information": self.appimage_update_information,
             }
         )
 

--- a/appimagebuilder/generator/templates/apt.yml.in
+++ b/appimagebuilder/generator/templates/apt.yml.in
@@ -55,5 +55,5 @@ AppDir:
 
 AppImage:
   arch: !Var appimage_arch
-  update-information: None
+  update-information: !Var appimage_update_information
   sign-key: None

--- a/appimagebuilder/generator/templates/files.yml.in
+++ b/appimagebuilder/generator/templates/files.yml.in
@@ -46,5 +46,5 @@ AppDir:
 
 AppImage:
   arch: !Var appimage_arch
-  update-information: None
+  update-information: !Var appimage_update_information
   sign-key: None


### PR DESCRIPTION
This PR aims in helping the user set the updateinformation on initializing appimage-builder. It would be helpful to let `appimagetool`, guess the update information by default rather than manually providing them. This would increase the number of appimages which are actually updateable