### PR TITLE
Pacman fixes

### DIFF
--- a/appimagebuilder/app_dir/deploy/pacman/venv.py
+++ b/appimagebuilder/app_dir/deploy/pacman/venv.py
@@ -168,7 +168,7 @@ class Venv:
             )
         )
 
-        self._run_command(
+        proc_gpgagent = self._run_command(
             "{fakeroot} {gpg-agent} --homedir {gpgdir} --daemon",
             assert_success=False,
             wait_for_completion=False
@@ -178,6 +178,8 @@ class Venv:
             "{fakeroot} {pacman-key} --config {config} --populate "
             f"{' '.join(keyrings)}"
         )
+
+        proc_gpgagent.terminate()
 
     def _run_command(
         self,

--- a/appimagebuilder/app_dir/deploy/pacman/venv.py
+++ b/appimagebuilder/app_dir/deploy/pacman/venv.py
@@ -9,6 +9,7 @@
 #
 #   The above copyright notice and this permission notice shall be included in
 #   all copies or substantial portions of the Software.
+import glob
 import logging
 import os
 import re
@@ -160,9 +161,17 @@ class Venv:
                         f.write("Server = %s\n" % server)
 
     def _configure_keyring(self):
+        keyrings = list(
+            map(
+                lambda x: x.split('.gpg')[0],
+                [os.path.basename(x) for x in glob.glob('/usr/share/pacman/keyrings/*.gpg')]
+            )
+        )
+
         self._run_command("{fakeroot} {pacman-key} --config {config} --init")
         self._run_command(
-            "{fakeroot} {pacman-key} --config {config} --populate archlinux"
+            "{fakeroot} {pacman-key} --config {config} --populate "
+            f"{' '.join(keyrings)}"
         )
 
     def _run_command(

--- a/appimagebuilder/app_dir/deploy/pacman/venv.py
+++ b/appimagebuilder/app_dir/deploy/pacman/venv.py
@@ -208,7 +208,7 @@ class Venv:
         :param kwargs: additional params which should be passed to format
         :return:
         """
-        command = command.format(config=self._config_path, gpgdir=self._gpg_dir, **self._deps, **kwargs)
+        command = command.format(config=self._config_path, **self._deps, **kwargs)
         # log it
         self._logger.debug(command)
 

--- a/appimagebuilder/app_dir/deploy/pacman/venv.py
+++ b/appimagebuilder/app_dir/deploy/pacman/venv.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 from appimagebuilder.common import shell
 
-DEPENDS_ON = ["bsdtar", "pacman", "pacman-key", "fakeroot"]
+DEPENDS_ON = ["bsdtar", "pacman", "pacman-key", "fakeroot", "gpg-agent"]
 
 
 class PacmanVenvError(RuntimeError):
@@ -168,6 +168,11 @@ class Venv:
             )
         )
 
+        self._run_command(
+            "{fakeroot} {gpg-agent} --homedir {gpgdir} --daemon",
+            assert_success=False,
+            wait_for_completion=False
+        )
         self._run_command("{fakeroot} {pacman-key} --config {config} --init")
         self._run_command(
             "{fakeroot} {pacman-key} --config {config} --populate "
@@ -193,7 +198,7 @@ class Venv:
         :param kwargs: additional params which should be passed to format
         :return:
         """
-        command = command.format(config=self._config_path, **self._deps, **kwargs)
+        command = command.format(config=self._config_path, gpgdir=self._gpg_dir, **self._deps, **kwargs)
         # log it
         self._logger.debug(command)
 


### PR DESCRIPTION
This PR fixes the issues with pacman deploy.

### Changes : 
  - Earlier only `archlinux` keyring was being populated and hence building appimages on manjaro failed because a keyring named `manjaro` needed to be populated too. With this fix, all available keyrings under `/usr/share/pacman/keyrings/*.gpg` will be populated.
  - When running `pacman-key` with `fakeroot` under manjaro host caused some issues with gpg-agent. With this fix, a gpg-agent is being started on the custom gpg homedir with `fakeroot` and this fixes the issue #77 

### To be done (Need help) : 
  - The gpg homedir path needs to be under 106 characters. If the path exceeds 106 characters, gpg-agent does not start and hence appimage generation fails. For this I would suggest that instead of having the `gnupg` directory in `appimage-builder-cache`, the gpg homedir can be stored in `~/.cache/appimage-builder` or some other cache directory so that the path doesn't exceeds 106 characters