### PR TITLE
Use apt args '--download-only -o Debug::pkgAcquire=1' 

### DIFF
--- a/appimagebuilder/builder/deploy/apt/package.py
+++ b/appimagebuilder/builder/deploy/apt/package.py
@@ -10,6 +10,7 @@
 #   The above copyright notice and this permission notice shall be included in
 #   all copies or substantial portions of the Software.
 import urllib
+from pathlib import Path
 
 from packaging import version
 
@@ -36,6 +37,17 @@ class Package:
 
     def get_apt_install_string(self):
         return "%s:%s=%s" % (self.name, self.arch, self.version)
+
+    @staticmethod
+    def from_file_path(path):
+        path = Path(path)
+        name_parts = path.stem.split("_")
+
+        return Package(
+            urllib.parse.unquote(name_parts[0]),
+            urllib.parse.unquote(name_parts[1]),
+            urllib.parse.unquote(name_parts[2]),
+        )
 
     def __eq__(self, other: object) -> bool:
         """Overrides the default implementation"""

--- a/examples/bash/AppImageBuilder.yml
+++ b/examples/bash/AppImageBuilder.yml
@@ -22,7 +22,7 @@ AppDir:
 
     include:
       - bash
-      - coreutils
+      - libc6
       - libc6:i386
     exclude:
       - libpcre3

--- a/tests/builder/delpoy/apt/test_venv.py
+++ b/tests/builder/delpoy/apt/test_venv.py
@@ -42,13 +42,6 @@ class TestVenv(TestCase):
     def test_search_packages(self):
         self.assertTrue(self.apt_venv.search_packages(["dpkg", "debconf"]))
 
-    def test_install_download_only(self):
-        packages = self.apt_venv.search_packages(["libc6"])
-        self.apt_venv.install_download_only(packages)
-
-        expected_path = "%s/libc6*.deb" % self.apt_venv._apt_archives_path
-        self.assertTrue(glob.glob(expected_path))
-
     def test_set_installed_packages(self):
         packages = self.apt_venv.search_packages(["dpkg", "debconf"])
         # dpkg and debconf need to be set as installed or the configuration step of apt-get install will fail
@@ -64,12 +57,12 @@ class TestVenv(TestCase):
                 "Package: debconf\n" "Status: install ok installed\n", file_contents
             )
 
-    def test_install_simulate(self):
+    def test_resolve_packages(self):
         packages = self.apt_venv.search_packages(["dpkg", "debconf"])
         # dpkg and debconf need to be set as installed or the configuration step of apt-get install will fail
         self.apt_venv.set_installed_packages(packages)
 
-        packages = self.apt_venv.install_simulate(["libc6"])
+        packages = self.apt_venv.resolve_packages(["libc6"])
         self.assertTrue(packages)
 
     def test_resolve_archive_paths(self):


### PR DESCRIPTION
Use apt args '--download-only -o Debug::pkgAcquire=1'  instead of '--simulate' to retrieve the full dependencies list.

This avoid executing any dpkg command which requires all the dependencies to be installed causing issues with dpkg and other base packages.

Closes #99