### PR TITLE
Prevent crash if empty file is marked executable

### DIFF
--- a/appimagebuilder/builder/runtime/executables_scanner.py
+++ b/appimagebuilder/builder/runtime/executables_scanner.py
@@ -96,7 +96,7 @@ class ExecutablesScanner:
         with open(path, "rb") as f:
             buf = f.read(128)
 
-            if buf[0] != ord("#") or buf[1] != ord("!"):
+            if len(buf) < 2 or buf[0] != ord("#") or buf[1] != ord("!"):
                 return None
 
             end_idx = buf.find(b"\n")


### PR DESCRIPTION
In the event that an empty file is marked executable, `read_shebang()` crashes with an index error. Resolve this by checking the length of `buf` before testing for a shebang.