### PR TITLE
Fix desktop entry search

### DIFF
--- a/appimagebuilder/generator/generator.py
+++ b/appimagebuilder/generator/generator.py
@@ -214,7 +214,7 @@ class RecipeGenerator:
         desktop_entries = []
         for file_name in os.listdir(os.path.abspath(self.app_dir)):
             if file_name.lower().endswith("desktop"):
-                desktop_entries.append(file_name)
+                desktop_entries.append(os.path.join(self.app_dir, file_name))
 
         for root, dir, files in os.walk(
             os.path.join(self.app_dir, "usr", "share", "applications")


### PR DESCRIPTION
Added `AppDir` root to the found desktop file. Should fix #120.