### PR TITLE
Add lookup for gdk-pixbuf-query-loaders-64

### DIFF
--- a/appimagebuilder/modules/setup/helpers/gdk_pixbuf.py
+++ b/appimagebuilder/modules/setup/helpers/gdk_pixbuf.py
@@ -67,7 +67,14 @@ class GdkPixbuf(BaseHelper):
         # shutil.which API. => $PATH
         if shutil.which("gdk-pixbuf-query-loaders"):
             return shutil.which("gdk-pixbuf-query-loaders")
-        raise RuntimeError("Missing 'gdk-pixbuf-query-loaders' executable")
+        # fedora provides gdk-pixbuf-query-loaders-64 instead 
+        # of gdk-pixbuf-query-loaders in /usr/bin
+        if shutil.which("gdk-pixbuf-query-loaders-64"):
+            return shutil.which("gdk-pixbuf-query-loaders-64")
+
+        raise RuntimeError(
+            "Missing 'gdk-pixbuf-query-loaders' "
+            "or 'gdk-pixbuf-query-loaders-64' executable")
 
     def _remove_loaders_path_prefixes(self, loaders_cache):
         output = []


### PR DESCRIPTION
Fedora 33 and 34 provide gdk-pixbuf-query-loaders-64 instead of gdk-pixbuf-query-loaders in /usr/bin
This pull request adds a lookup for gdk-pixbuf-query-loaders-64 in the PATH if previous lookups fail.
This fixes #149.