### PR TITLE
Fix error when icon size cannot be guesed

### DIFF
--- a/appimagebuilder/modules/setup/icon_bundler.py
+++ b/appimagebuilder/modules/setup/icon_bundler.py
@@ -75,7 +75,7 @@ class IconBundler:
                 new_path = os.path.join(root, png_icon_name)
                 new_size = self._extract_icon_size_from_path(new_path)
 
-                if new_size > size:
+                if new_size >= size:
                     size = new_size
                     path = new_path
 


### PR DESCRIPTION
Since `_search_icon()` function defaults `size = 0` and `path = None`, when `_extract_icon_size_from_path()` fails to get the size it will `return 0` thus the `path` variable never is updated for an icon that is at the root `/usr/share/icons`