### PR TITLE
Update MIME Database During AppImage Build

### DIFF
--- a/appimagebuilder/modules/setup/generator.py
+++ b/appimagebuilder/modules/setup/generator.py
@@ -152,7 +152,7 @@ class RuntimeGenerator:
             helpers.OpenSSL,
             helpers.Python,
             helpers.Qt,
-            helpers.Mime,
+            helpers.MIME,
         ]
 
         for helper in execution_list:

--- a/appimagebuilder/modules/setup/generator.py
+++ b/appimagebuilder/modules/setup/generator.py
@@ -152,6 +152,7 @@ class RuntimeGenerator:
             helpers.OpenSSL,
             helpers.Python,
             helpers.Qt,
+            helpers.Mime,
         ]
 
         for helper in execution_list:

--- a/appimagebuilder/modules/setup/helpers/__init__.py
+++ b/appimagebuilder/modules/setup/helpers/__init__.py
@@ -20,4 +20,4 @@ from .libgl import LibGL
 from .openssl import OpenSSL
 from .python import Python
 from .qt import Qt
-from .mime import Mime
+from .mime import MIME

--- a/appimagebuilder/modules/setup/helpers/mime.py
+++ b/appimagebuilder/modules/setup/helpers/mime.py
@@ -15,7 +15,7 @@ import subprocess
 from .base_helper import BaseHelper
 
 
-class Mime(BaseHelper):
+class MIME(BaseHelper):
     def configure(self, env, preserve_files):
         path = self.finder.base_path / "usr" / "share" / "mime"
         if path.is_dir():

--- a/appimagebuilder/modules/setup/helpers/mime.py
+++ b/appimagebuilder/modules/setup/helpers/mime.py
@@ -1,4 +1,4 @@
-#  Copyright  2020 Alexis Lopez Zubieta
+#  Copyright  2022 TheBrokenRail
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a
 #  copy of this software and associated documentation files (the "Software"),
@@ -9,15 +9,18 @@
 #
 #  The above copyright notice and this permission notice shall be included in
 #  all copies or substantial portions of the Software.
+import shutil
+import subprocess
 
-from .gdk_pixbuf import GdkPixbuf
-from .glib import GLib
-from .gstreamer import GStreamer
-from .gtk import Gtk
-from .libc import LibC
-from .java import Java
-from .libgl import LibGL
-from .openssl import OpenSSL
-from .python import Python
-from .qt import Qt
-from .mime import Mime
+from .base_helper import BaseHelper
+
+
+class Mime(BaseHelper):
+    def configure(self, env, preserve_files):
+        path = self.finder.base_path / "usr" / "share" / "mime"
+        if path.is_dir():
+            bin_path = shutil.which("update-mime-database")
+            if not bin_path:
+                raise RuntimeError("Missing 'update-mime-database' executable")
+
+            subprocess.run([bin_path, path])


### PR DESCRIPTION
This helps prevent nasty errors like:
```
(zenity:859894): Gtk-WARNING **: 18:19:45.629: Could not load a pixbuf from /org/gtk/libgtk/icons/16x16/status/image-missing.png.
This may indicate that pixbuf loaders or the mime database could not be found.
**
Gtk:ERROR:../../../../gtk/gtkiconhelper.c:494:ensure_surface_for_gicon: assertion failed (error == NULL): Failed to load /org/gtk/libgtk/icons/16x16/status/image-missing.png: Unrecognized image file format (gdk-pixbuf-error-quark, 3)
```
It does require the developer to include `shared-mime-info` in their package includes.