### PR TITLE
Generate Correct Arch In `X-AppImage-Arch`

### DIFF
--- a/appimagebuilder/commands/setup_app_info.py
+++ b/appimagebuilder/commands/setup_app_info.py
@@ -29,4 +29,4 @@ class SetupAppInfoCommand(Command):
         icon_bundler.bundle_icon()
 
         desktop_entry_generator = DesktopEntryGenerator(self.context.app_dir)
-        desktop_entry_generator.generate(self.context.app_info)
+        desktop_entry_generator.generate(self.context.app_info, self.context.bundle_info.runtime_arch)

--- a/appimagebuilder/modules/setup/desktop_entry_generator.py
+++ b/appimagebuilder/modules/setup/desktop_entry_generator.py
@@ -11,7 +11,6 @@
 #  all copies or substantial portions of the Software.
 import logging
 import os
-import platform
 
 
 class DesktopEntryGenerator:
@@ -23,7 +22,7 @@ class DesktopEntryGenerator:
         self.contents = []
         self.app_dir = app_dir
 
-    def generate(self, app_info):
+    def generate(self, app_info, arch):
         try:
             self._load_app_desktop_entry(app_info.id)
         except DesktopEntryGenerator.Error as err:
@@ -32,7 +31,7 @@ class DesktopEntryGenerator:
 
         self._add_appimage_name(app_info.name)
         self._add_appimage_version(app_info.version)
-        self._add_appimage_arch(platform.machine())
+        self._add_appimage_arch(arch)
 
         self._save_app_dir_desktop_entry(app_info.id)
 


### PR DESCRIPTION
Otherwise, `X-AppImage-Arch` would always be the host's architecture.