### PR TITLE
Fix Wrong Variable Name In setup_symlinks.py

### DIFF
--- a/appimagebuilder/commands/setup_symlinks.py
+++ b/appimagebuilder/commands/setup_symlinks.py
@@ -43,7 +43,7 @@ class SetupSymlinksCommand(Command):
         for link in self._finder.find("*", [Finder.is_symlink]):
             allowed = True
             for preserve_file in self._preserve_files:
-                if preserve_file.samefile(bin):
+                if preserve_file.samefile(link):
                     allowed = False
                     break
             if allowed:

--- a/appimagebuilder/commands/setup_symlinks.py
+++ b/appimagebuilder/commands/setup_symlinks.py
@@ -43,7 +43,7 @@ class SetupSymlinksCommand(Command):
         for link in self._finder.find("*", [Finder.is_symlink]):
             allowed = True
             for preserve_file in self._preserve_files:
-                if preserve_file.samefile(link):
+                if str(preserve_file) == str(link):
                     allowed = False
                     break
             if allowed:

--- a/appimagebuilder/modules/setup/generator.py
+++ b/appimagebuilder/modules/setup/generator.py
@@ -108,7 +108,7 @@ class RuntimeGenerator:
         for executable in interpreted_executables:
             allowed = True
             for preserve_file in preserve_files:
-                if preserve_file.samefile(executable):
+                if str(preserve_file) == str(executable):
                     allowed = False
                     break
             if allowed:

--- a/appimagebuilder/modules/setup/generator.py
+++ b/appimagebuilder/modules/setup/generator.py
@@ -72,19 +72,7 @@ class RuntimeGenerator:
         self._deploy_apprun(resolver)
 
     def _get_preserve_files(self):
-        preserve_files = []
-        base_paths = [
-            self.finder.base_path,
-            self.finder.base_path / "runtime" / "compat",
-        ]
-        for pattern in self.preserve_paths:
-            for base_path in base_paths:
-                for match in base_path.glob(pattern):
-                    if match.is_dir():
-                        preserve_files.extend(match.glob("**/*"))
-                    else:
-                        preserve_files.append(match)
-        return preserve_files
+        return self.finder.get_preserve_files(self.preserve_paths)
 
     def _setup_path_mappings(self, runtime_env, interpreter_paths: list):
         # map used interpreters
@@ -106,12 +94,7 @@ class RuntimeGenerator:
 
         preserve_files = self._get_preserve_files()
         for executable in interpreted_executables:
-            allowed = True
-            for preserve_file in preserve_files:
-                if str(preserve_file) == str(executable):
-                    allowed = False
-                    break
-            if allowed:
+            if Finder.list_does_not_contain_file(preserve_files, executable.path):
                 patcher.patch_interpreted_executable(executable.path)
 
     def _find_embed_archs(self, executables):

--- a/appimagebuilder/modules/setup/helpers/libc.py
+++ b/appimagebuilder/modules/setup/helpers/libc.py
@@ -123,12 +123,7 @@ class LibC(BaseHelper):
             ],
         )
         for bin_path in binaries:
-            allowed = True
-            for preserve_file in preserve_files:
-                if str(preserve_file) == str(bin_path):
-                    allowed = False
-                    break
-            if allowed:
+            if Finder.list_does_not_contain_file(preserve_files, bin_path):
                 self._make_interpreter_path_relative(bin_path)
 
     def _make_interpreter_path_relative(self, bin_path):

--- a/appimagebuilder/modules/setup/helpers/libc.py
+++ b/appimagebuilder/modules/setup/helpers/libc.py
@@ -125,7 +125,7 @@ class LibC(BaseHelper):
         for bin_path in binaries:
             allowed = True
             for preserve_file in preserve_files:
-                if preserve_file.samefile(bin):
+                if str(preserve_file) == str(bin_path):
                     allowed = False
                     break
             if allowed:

--- a/appimagebuilder/utils/finder.py
+++ b/appimagebuilder/utils/finder.py
@@ -160,3 +160,27 @@ class Finder:
             passed = check_function(path)
             self.cache[key] = passed
             return passed
+
+    @staticmethod
+    def list_does_not_contain_file(file_list: [pathlib.Path], file: pathlib.Path):
+        allowed = True
+        for item in file_list:
+            if str(item) == str(file):
+                allowed = False
+                break
+        return allowed
+
+    def get_preserve_files(self, preserve_paths: [str]):
+        _preserve_files = []
+        base_paths = [
+            self.base_path,
+            self.base_path / "runtime" / "compat",
+        ]
+        for pattern in preserve_paths:
+            for base_path in base_paths:
+                for match in base_path.glob(pattern):
+                    if match.is_dir():
+                        _preserve_files.extend(match.glob("**/*"))
+                    else:
+                        _preserve_files.append(match)
+        return _preserve_files

--- a/appimagebuilder/utils/finder.py
+++ b/appimagebuilder/utils/finder.py
@@ -163,12 +163,10 @@ class Finder:
 
     @staticmethod
     def list_does_not_contain_file(file_list: [pathlib.Path], file: pathlib.Path):
-        allowed = True
         for item in file_list:
-            if str(item) == str(file):
-                allowed = False
-                break
-        return allowed
+            if item == file:
+                return False
+        return True
 
     def get_preserve_files(self, preserve_paths: [str]):
         _preserve_files = []


### PR DESCRIPTION
Fixes

```
Traceback (most recent call last):
  File "/usr/local/bin/appimage-builder", line 8, in <module>
    sys.exit(__main__())
  File "/usr/local/lib/python3.8/dist-packages/appimagebuilder/__main__.py", line 44, in __main__
    invoker.execute(commands)
  File "/usr/local/lib/python3.8/dist-packages/appimagebuilder/invoker.py", line 29, in execute
    command()
  File "/usr/local/lib/python3.8/dist-packages/appimagebuilder/commands/setup_symlinks.py", line 46, in __call__
    if preserve_file.samefile(bin):
  File "/usr/lib/python3.8/pathlib.py", line 1113, in samefile
    other_st = os.stat(other_path)
TypeError: stat: path should be string, bytes, os.PathLike or integer, not builtin_function_or_method
```