### PR TITLE
Dockerfile: bump base image to Ubuntu 20.04 from 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get -y install python3 python3-setuptools python3-pip wget fakeroot gnupg2 libglib2.0-bin file \
+RUN apt-get update && apt-get -yq install python3 python3-setuptools python3-pip wget fakeroot gnupg2 libglib2.0-bin file \
  desktop-file-utils libgdk-pixbuf2.0-dev librsvg2-dev libyaml-dev zsync gtk-update-icon-cache strace elfutils
 
 ADD . /opt/appimage-builder
@@ -22,4 +23,4 @@ RUN wget https://github.com/NixOS/patchelf/releases/download/0.12/patchelf-0.12.
     rm -rf patchelf-*
 
 WORKDIR /
-RUN apt-get -y autoclean
+RUN apt-get -yq autoclean


### PR DESCRIPTION
The latest appimage-builder alpha release at the time of writing, v1.0.0-alpha.3, assumes that at least Python 3.8 is available. However, Ubuntu 18.04 ships Python 3.6, and as such the Docker container errors out at runtime when trying to import types that were added in Python 3.8:

```
Traceback (most recent call last):
  File "/usr/local/bin/appimage-builder", line 11, in <module>
    load_entry_point('appimage-builder==1.0.0a3', 'console_scripts', 'appimage-builder')()
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 480, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2693, in load_entry_point
    return ep.load()
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2324, in load
    return self.resolve()
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2330, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/local/lib/python3.6/dist-packages/appimage_builder-1.0.0a3-py3.6.egg/appimagebuilder/__main__.py", line 32, in <module>
    from appimagebuilder.invoker import Invoker
  File "/usr/local/lib/python3.6/dist-packages/appimage_builder-1.0.0a3-py3.6.egg/appimagebuilder/invoker.py", line 26, in <module>
    from appimagebuilder.commands.command import Command
  File "/usr/local/lib/python3.6/dist-packages/appimage_builder-1.0.0a3-py3.6.egg/appimagebuilder/commands/__init__.py", line 22, in <module>
    from .setup_runtime import SetupRuntimeCommand
  File "/usr/local/lib/python3.6/dist-packages/appimage_builder-1.0.0a3-py3.6.egg/appimagebuilder/commands/setup_runtime.py", line 12, in <module>
    from appimagebuilder.modules.setup.generator import RuntimeGenerator
  File "/usr/local/lib/python3.6/dist-packages/appimage_builder-1.0.0a3-py3.6.egg/appimagebuilder/modules/setup/generator.py", line 18, in <module>
    from typing import Final
ImportError: cannot import name 'Final'
```

Update the base image to something more modern, Ubuntu 20.04, to fix this issue. Setting the DEBIAN_FRONTEND and -yq parameter to apt-get was necessary to avoid `docker build` interactively prompting for timezone data configuration parameters, due to the `tzdata` Ubuntu package.