### PR TITLE
Fix Another Small Typo

### DIFF
--- a/appimagebuilder/utils/shell.py
+++ b/appimagebuilder/utils/shell.py
@@ -20,7 +20,7 @@ def require_executables(executables: [str]):
 def require_executable(tool):
     tool_path = shutil.which(tool)
     if not tool_path:
-        raise CommandNotFoundError("Could not find '{exe}' on $PATH.".format(exe=dep))
+        raise CommandNotFoundError("Could not find '{exe}' on $PATH.".format(exe=tool))
 
     return tool_path
 


### PR DESCRIPTION
Fixes
```
Traceback (most recent call last):
  File "/usr/local/bin/appimage-builder", line 8, in <module>
    sys.exit(__main__())
  File "/usr/local/lib/python3.9/dist-packages/appimagebuilder/__main__.py", line 50, in __main__
    invoker.execute(commands)
  File "/usr/local/lib/python3.9/dist-packages/appimagebuilder/invoker.py", line 29, in execute
    command()
  File "/usr/local/lib/python3.9/dist-packages/appimagebuilder/commands/apt_deploy.py", line 42, in __call__
    apt_venv = self._setup_apt_venv()
  File "/usr/local/lib/python3.9/dist-packages/appimagebuilder/commands/apt_deploy.py", line 60, in _setup_apt_venv
    apt_venv = Venv(
  File "/usr/local/lib/python3.9/dist-packages/appimagebuilder/modules/deploy/apt/venv.py", line 39, in __init__
    self._deps = shell.require_executables(DEPENDS_ON)
  File "/usr/local/lib/python3.9/dist-packages/appimagebuilder/utils/shell.py", line 16, in require_executables
    paths[dep] = require_executable(dep)
  File "/usr/local/lib/python3.9/dist-packages/appimagebuilder/utils/shell.py", line 23, in require_executable
    raise CommandNotFoundError("Could not find '{exe}' on $PATH.".format(exe=dep))
NameError: name 'dep' is not defined
```