### PR TITLE
Remove existing .DirIcon before creating new symlink

### DIFF
--- a/appimagebuilder/modules/setup/icon_bundler.py
+++ b/appimagebuilder/modules/setup/icon_bundler.py
@@ -37,7 +37,10 @@ class IconBundler:
                 % (source_icon_path, os.path.relpath(target_icon_path, self.app_dir))
             )
             shutil.copyfile(source_icon_path, target_icon_path)
-            os.symlink(os.path.basename(source_icon_path), self.app_dir / ".DirIcon")
+            app_dir_icon_path = self.app_dir / ".DirIcon"
+            if os.path.exists(app_dir_icon_path):
+                os.remove(app_dir_icon_path)
+            os.symlink(os.path.basename(source_icon_path), app_dir_icon_path)
         except Exception:
             raise IconBundler.Error(
                 "Unable to copy icon from: %s to %s"


### PR DESCRIPTION

Remove .DirIcon symlink if it exists before creating the new symlink to avoid a FileExistsError exception.

This method of symlink replacement is not an atomic operation, but shouldn't be an issue in this case.