### PR TITLE
Add error if docker isn't present

### DIFF
--- a/appimagebuilder/commands/run_test.py
+++ b/appimagebuilder/commands/run_test.py
@@ -17,6 +17,8 @@ from appimagebuilder.recipe.roamer import Roamer
 from appimagebuilder.modules.test import ExecutionTest, TestFailed
 from ..context import Context
 
+import docker
+from docker.errors import DockerException
 
 class RunTestCommand(Command):
     def __init__(self, context: Context, tests_settings: Roamer):
@@ -28,7 +30,14 @@ class RunTestCommand(Command):
         return "test"
 
     def __call__(self, *args, **kwargs):
-        test_cases = self._load_tests(self.tests_settings())
+        try:
+            test_cases = self._load_tests(self.tests_settings())
+        except DockerException as e:
+            logging.error("Docker error : "+str(e))
+            logging.error("(Is docker installed/started ?)")
+            logging.error("Tests will be skipped")
+            return
+
         try:
             for test in test_cases:
                 test.run()


### PR DESCRIPTION
If docker isn't present/started on the system, appimage-builder (the docker module) will throw a *really* big error, that doesn't say very much about the problem (https://paste.gg/p/anonymous/cf2a294c754b49e1bd0139871fd7e965)

This PR adds a try/catch and tell the user an error has occured with docker
