### PR TITLE
do not deploy empty package set with pacman

### DIFF
--- a/appimagebuilder/modules/deploy/pacman/deploy.py
+++ b/appimagebuilder/modules/deploy/pacman/deploy.py
@@ -52,6 +52,10 @@ class Deploy:
         self.logger = logging.getLogger("PacmanPackageDeploy")
 
     def deploy(self, packages: [str], appdir_root: str, exclude: [str] = None):
+        if not packages:
+            # quick return if there is no packages to be deployed
+            return
+
         self.pacman_venv.update()
 
         appdir_root = Path(appdir_root)


### PR DESCRIPTION
appimage-builder currently crashes with this config because it tries to do something like `pacman -S` (with no packages appended):
```yml
pacman:
  include: []
```

I simply copied this block from the apt deploy script to fix it : https://github.com/AppImageCrafters/appimage-builder/blob/bd82930fccbe63a0d412288d9b645adb951f65ee/appimagebuilder/modules/deploy/apt/deploy.py#L35