### PR TITLE
Use zstd compression instead of xz

### DIFF
--- a/appimagebuilder/modules/prime/appimage_primer.py
+++ b/appimagebuilder/modules/prime/appimage_primer.py
@@ -83,7 +83,7 @@ class AppImagePrimer(BasePrimer):
             "-noappend",
             "-reproducible",
             "-comp",
-            "xz",
+            "zstd",
         ]
         self.logger.info("Creating squashfs from AppDir")
         self.logger.debug(" ".join(command))


### PR DESCRIPTION

> Hi @adil192, thanks for submitting.
Now I am curious: The squashfs image inside this AppImage uses xz compression, whereas we normally use zlib (old) or zstd (new). Did you make this choice intentionally?

https://github.com/AppImage/appimage.github.io/pull/3066#issuecomment-1339790360


This PR uses `zstd` compression instead of `xz`, referencing https://manpages.debian.org/testing/squashfs-tools/mksquashfs.1.en.html#comp. I haven't tested if this works though.