### PR TITLE
Fix missing interpreter for aarch64 architecture

### DIFF
--- a/appimagebuilder/modules/setup/file_matching_patterns.py
+++ b/appimagebuilder/modules/setup/file_matching_patterns.py
@@ -30,6 +30,7 @@ glibc = [
     "**/ld-linux-x86-64.so*",
     "**/ld-linux-x86-64.so*",
     "**/ld-linux-x86-64.so.2",
+    "**/ld-linux-aarch64.so*",
     "**/ld-linux.so.2",
     "**/libBrokenLocale-*.so",
     "**/libBrokenLocale.so*",


### PR DESCRIPTION
Without the aarch64 linux interpreter in the patterns, the interpreter is not placed under the runtime/compat directory. This fixes #272.