### PR TITLE
do not force python 3.8 in CI

### DIFF
--- a/.github/workflows/continuous-builds.yml
+++ b/.github/workflows/continuous-builds.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          sudo apt install -y python3.8-minimal python3-pip python3-setuptools patchelf desktop-file-utils libgdk-pixbuf2.0-dev fakeroot strace git
+          sudo apt install -y python3-minimal python3-pip python3-setuptools patchelf desktop-file-utils libgdk-pixbuf2.0-dev fakeroot strace git
           sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
           sudo chmod +x /usr/local/bin/appimagetool
       - uses: actions/checkout@v3
@@ -56,7 +56,7 @@ jobs:
         run: |
           git config --global --add safe.directory $PWD
           git fetch --prune --unshallow
-          sudo python3.8 -m pip install .
+          sudo python3 -m pip install .
       - name: Build AppImage
         run: |
           cd recipes/appimage-builder

--- a/.github/workflows/continuous-builds.yml
+++ b/.github/workflows/continuous-builds.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          sudo apt install -y python3-minimal python3-pip python3-setuptools patchelf desktop-file-utils libgdk-pixbuf2.0-dev fakeroot strace git
+          sudo apt install -y python3.11-minimal python3-pip python3-setuptools patchelf desktop-file-utils libgdk-pixbuf2.0-dev fakeroot strace git
           sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
           sudo chmod +x /usr/local/bin/appimagetool
       - uses: actions/checkout@v3

--- a/.github/workflows/continuous-builds.yml
+++ b/.github/workflows/continuous-builds.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update 
-          apt-get install -y python3 python3-pip python3-pytest fakeroot binutils patchelf git
+          apt-get install -y python3.11 python3-pip python3-pytest fakeroot binutils patchelf git
       - uses: actions/checkout@v3
       - name: Install appimage-builder
         run: |
@@ -56,7 +56,7 @@ jobs:
         run: |
           git config --global --add safe.directory $PWD
           git fetch --prune --unshallow
-          sudo python3 -m pip install .
+          sudo python3.11 -m pip install .
       - name: Build AppImage
         run: |
           cd recipes/appimage-builder


### PR DESCRIPTION
Ubuntu 22.04 do not have python 3.8 installed anymore

`pip install appimage-builder` will also install appimage-builder with other python versions (such as 3.11), so I don't see the need to force python3.8 with github releases specifically