### PR TITLE
Small CI fixes

### DIFF
--- a/.github/workflows/continuous-builds.yml
+++ b/.github/workflows/continuous-builds.yml
@@ -33,7 +33,7 @@ jobs:
     container: archlinux
     steps:
       - name: Install dependencies
-        run: pacman -Sy --noconfirm python-pip python-pytest python-setuptools binutils patchelf fakeroot strace patchelf git
+        run: pacman -Syu --noconfirm python-pip python-pytest python-setuptools binutils patchelf fakeroot strace patchelf git
       - uses: actions/checkout@v3
       - name: Install appimage-builder
         run: |

--- a/.github/workflows/continuous-builds.yml
+++ b/.github/workflows/continuous-builds.yml
@@ -35,7 +35,8 @@ jobs:
       - name: Install dependencies
         run: pacman -Sy --noconfirm python-pip python-pytest python-setuptools binutils patchelf fakeroot strace patchelf git
       - uses: actions/checkout@v3
-      - run: |
+      - name: Install appimage-builder
+        run: |
           git config --global --add safe.directory $PWD
           git fetch --prune --unshallow
           python3 -m pip install -e .[dev]


### PR DESCRIPTION
Two small fixes to the CI

The second one is because : https://wiki.archlinux.org/title/System_maintenance#Partial_upgrades_are_unsupported
This means that ArchLinux could completely break on each CI run