### PR TITLE
Fixes #272 and #278 for armhf architecture

### DIFF
--- a/appimagebuilder/modules/setup/file_matching_patterns.py
+++ b/appimagebuilder/modules/setup/file_matching_patterns.py
@@ -31,6 +31,7 @@ glibc = [
     "**/ld-linux-x86-64.so*",
     "**/ld-linux-x86-64.so.2",
     "**/ld-linux-aarch64.so*",
+    "**/ld-linux-armhf.so*",
     "**/ld-linux.so.2",
     "**/libBrokenLocale-*.so",
     "**/libBrokenLocale.so*",


### PR DESCRIPTION
Recently build AppImages are not working for armhf and require a similar change as seen in #283 