### PR TITLE
Ensure dpkg configuration is correct for aarch64

### DIFF
--- a/appimagebuilder/modules/deploy/apt/venv.py
+++ b/appimagebuilder/modules/deploy/apt/venv.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from urllib import request
 
 from appimagebuilder.utils import shell
+from appimagebuilder.utils.dpkg_architecture import DpkgArchitecture
 from .package import Package
 
 DEPENDS_ON = ["dpkg-deb", "apt-get", "apt-key", "fakeroot", "apt-cache"]
@@ -69,6 +70,7 @@ class Venv:
         self._dpkg_status_path.touch(exist_ok=True)
 
     def _write_apt_conf(self, user_options, architectures: [str]):
+        architectures = [a.replace("aarch64", "arm64") for a in architectures]
         options = {
             "Dir": self._base_path,
             "Dir::State": self._base_path,
@@ -180,7 +182,8 @@ class Venv:
         return proc
 
     def resolve_packages(self, packages: [Package]) -> [Package]:
-        packages_str = [str(package) for package in packages]
+        dpkg_architecture = DpkgArchitecture()
+        packages_str = [str(package)+":"+str(dpkg_architecture) for package in packages]
         output = self._run_apt_get_install_download_only(packages_str)
 
         stdout_str = output.stderr.decode("utf-8")

--- a/appimagebuilder/modules/deploy/apt/venv.py
+++ b/appimagebuilder/modules/deploy/apt/venv.py
@@ -183,7 +183,7 @@ class Venv:
 
     def resolve_packages(self, packages: [Package]) -> [Package]:
         dpkg_architecture = DpkgArchitecture()
-        packages_str = [str(package)+":"+str(dpkg_architecture) for package in packages]
+        packages_str = [str(package) for package in packages]
         output = self._run_apt_get_install_download_only(packages_str)
 
         stdout_str = output.stderr.decode("utf-8")

--- a/appimagebuilder/modules/deploy/apt/venv.py
+++ b/appimagebuilder/modules/deploy/apt/venv.py
@@ -21,7 +21,6 @@ from pathlib import Path
 from urllib import request
 
 from appimagebuilder.utils import shell
-from appimagebuilder.utils.dpkg_architecture import DpkgArchitecture
 from .package import Package
 
 DEPENDS_ON = ["dpkg-deb", "apt-get", "apt-key", "fakeroot", "apt-cache"]
@@ -70,6 +69,7 @@ class Venv:
         self._dpkg_status_path.touch(exist_ok=True)
 
     def _write_apt_conf(self, user_options, architectures: [str]):
+        # aarch64 will fail on ubuntu as the repositories indexes only cater for arm64 name
         architectures = [a.replace("aarch64", "arm64") for a in architectures]
         options = {
             "Dir": self._base_path,
@@ -182,7 +182,6 @@ class Venv:
         return proc
 
     def resolve_packages(self, packages: [Package]) -> [Package]:
-        dpkg_architecture = DpkgArchitecture()
         packages_str = [str(package) for package in packages]
         output = self._run_apt_get_install_download_only(packages_str)
 


### PR DESCRIPTION
While trying to build an appimage for ubuntu that has an `apt` section i discovered that ubuntu does not really like, at least in older yet supported LTS versions, the `aarch64` name for this architecture. 
As a result, `apt-get` invocations fail with `no candidate for this package` error, since the packages available for `arm64` are not considered for installation.