### PR TITLE
Add missing squashfs-tools depenedency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && \
         python3-setuptools \
         strace \
         wget \
+        squashfs-tools \
         zsync && \
     apt-get -yq autoclean
 


### PR DESCRIPTION
While using the GitHub Action / the Docker image there is an issue that mksquashfs is missing from path. Currently people are working around that with: #271  

The action hasn't seen an update in forever let's not break builds going forwards by at least allowing people to use the docker image