### PR TITLE
[Fix] Read 'AppDir' path from recipe file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # PyCharm
 .idea
 
+# vscode
+.vscode
+
 # Example builds
 /recipes/*/AppDir
 /recipes/*/appimage-build

--- a/appimagebuilder/commands/deploy_record.py
+++ b/appimagebuilder/commands/deploy_record.py
@@ -11,6 +11,7 @@
 #  all copies or substantial portions of the Software.
 import logging
 import os
+from pathlib import PosixPath
 
 from ruamel.yaml import YAML
 
@@ -25,7 +26,7 @@ class WriteDeployRecordCommand(Command):
         return "write-deploy-record"
 
     def __call__(self, *args, **kwargs):
-        path = self.context.app_dir / ".bundle.yml"
+        path = (PosixPath(self.context.recipe.AppDir.path()) or self.context.app_dir) / ".bundle.yml"
         with open(path, "w") as f:
             logging.info(
                 "Writing deploy record to: %s"

--- a/appimagebuilder/commands/setup_app_info.py
+++ b/appimagebuilder/commands/setup_app_info.py
@@ -15,7 +15,7 @@ from appimagebuilder.modules.setup.desktop_entry_generator import (
 from appimagebuilder.modules.setup.icon_bundler import IconBundler
 from appimagebuilder.context import AppInfo, Context
 from appimagebuilder.commands.command import Command
-
+from pathlib import PosixPath
 
 class SetupAppInfoCommand(Command):
     def __init__(self, context: Context):
@@ -25,10 +25,11 @@ class SetupAppInfoCommand(Command):
         return "app-info-setup"
 
     def __call__(self, *args, **kwargs):
-        icon_bundler = IconBundler(self.context.app_dir, self.context.app_info.icon)
+        appdir_path = PosixPath(self.context.recipe.AppDir.path()) or self.context.app_dir
+        icon_bundler = IconBundler(appdir_path, self.context.app_info.icon)
         icon_bundler.bundle_icon()
 
-        desktop_entry_generator = DesktopEntryGenerator(self.context.app_dir)
+        desktop_entry_generator = DesktopEntryGenerator(appdir_path)
         desktop_entry_generator.generate(
             self.context.app_info, self.context.bundle_info.runtime_arch
         )

--- a/appimagebuilder/modules/prime/appimage_primer.py
+++ b/appimagebuilder/modules/prime/appimage_primer.py
@@ -42,8 +42,9 @@ class AppImagePrimer(BasePrimer):
         if not self.carrier_path.exists():
             self._get_appimage_kit_runtime()
 
+        appdir_path = pathlib.PosixPath(self.context.recipe.AppDir.path()) or self.context.app_dir
         # create payload
-        payload_path = self._make_squashfs(self.context.app_dir)
+        payload_path = self._make_squashfs(appdir_path)
 
         # prepare carrier (a.k.a. "runtime" using a different name to differentiate from the AppRun settings)
         shutil.copyfile(self.carrier_path, self.appimage_path)

--- a/appimagebuilder/modules/setup/apprun_2/apprun2.py
+++ b/appimagebuilder/modules/setup/apprun_2/apprun2.py
@@ -61,7 +61,7 @@ class AppRunV2Setup:
         self.context = context
         recipe = context.recipe
 
-        self.appdir_path = self.context.app_dir
+        self.appdir_path = recipe.AppDir.path() or self.context.app_dir
         self.main_exec = recipe.AppDir.app_info.exec()
         self.main_exec_args = recipe.AppDir.app_info.exec_args() or "$@"
         self.apprun_version = recipe.AppDir.runtime.version() or "v2.0.0"

--- a/appimagebuilder/modules/setup/apprun_2/apprun2.py
+++ b/appimagebuilder/modules/setup/apprun_2/apprun2.py
@@ -27,7 +27,7 @@ import os
 import random
 import shutil
 import string
-from pathlib import Path
+from pathlib import Path, PosixPath
 from typing import Final
 
 from packaging import version
@@ -61,7 +61,7 @@ class AppRunV2Setup:
         self.context = context
         recipe = context.recipe
 
-        self.appdir_path = recipe.AppDir.path() or self.context.app_dir
+        self.appdir_path = PosixPath(recipe.AppDir.path()) or self.context.app_dir
         self.main_exec = recipe.AppDir.app_info.exec()
         self.main_exec_args = recipe.AppDir.app_info.exec_args() or "$@"
         self.apprun_version = recipe.AppDir.runtime.version() or "v2.0.0"

--- a/appimagebuilder/orchestrator.py
+++ b/appimagebuilder/orchestrator.py
@@ -108,7 +108,11 @@ class Orchestrator:
             )
             commands.append(command)
 
-        finder = Finder(context.app_dir)
+        if os.path.exists(recipe.AppDir.path()):
+            finder = Finder(pathlib.PosixPath(recipe.AppDir.path()))
+        else:
+            finder = Finder(context.app_dir)
+
         commands.append(SetupSymlinksCommand(context, recipe, finder))
 
         commands.append(SetupRuntimeCommand(context, finder))


### PR DESCRIPTION
Currently this tool only searches for the AppDir in the current working directory (unless `--appdir` is used) and completely ignores the path defined in the recipe file.

This PR fixes that.

The hirearchy of importance is:

1. `--appdir` (if used)
2. `recipe.AppDir.path` (if found)
3. defaults to searching for `AppDir` in the current working directory