### PR TITLE
[Fix] Read 'AppDir' path from recipe file. (v2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # PyCharm
 .idea
 
+# vscode
+.vscode/*
+
 # Example builds
 /recipes/*/AppDir
 /recipes/*/appimage-build

--- a/appimagebuilder/orchestrator.py
+++ b/appimagebuilder/orchestrator.py
@@ -157,7 +157,11 @@ class Orchestrator:
         )
 
     def _extract_v1_recipe_context(self, args, recipe):
-        app_dir_path = pathlib.Path(args.appdir).absolute()
+        if recipe.AppDir.path() and os.path.exists(recipe.AppDir.path()):
+            app_dir_path = pathlib.Path(recipe.AppDir.path()).absolute()
+        else:
+            app_dir_path = pathlib.Path(args.appdir).absolute()
+
         build_dir_path = pathlib.Path(args.build_dir).absolute()
 
         app_info_section = recipe.AppDir.app_info


### PR DESCRIPTION
Currently this tool only looks for the AppDir in the current working directory (unless `--appdir` is used) and completely ignores the path defined in the recipe file.

This PR fixes that.

The hirearchy of importance is:


1. `recipe.AppDir.path()` (if defined and found)
2. `--appdir` argument (if used)
3. defaults to searching for `AppDir` in the current working directory


*we don't talk about https://github.com/AppImageCrafters/appimage-builder/pull/326*