### PR TITLE
Bootstrap fixes2

### DIFF
--- a/appimagebuilder/commands/setup_runtime.py
+++ b/appimagebuilder/commands/setup_runtime.py
@@ -30,12 +30,10 @@ class SetupRuntimeCommand(Command):
         apprun_version = self.context.recipe.AppDir.runtime.version() or "v2.0.0"
         apprun_version = version.parse(apprun_version)
         runtime_setup = None
-        if (
-            version.parse("v2.0.0") <= apprun_version < version.parse("v3.0.0")
-        ) or apprun_version == version.parse("continuous"):
+        if version.parse("v2.0.0") <= apprun_version < version.parse("v3.0.0"):
             runtime_setup = AppRunV2Setup(self.context, self._finder)
 
-        if not runtime_setup and version.parse("v3.0.0-devel") <= apprun_version < version.parse("v4.0.0"):
+        if not runtime_setup and version.parse("v3.0.0") <= apprun_version < version.parse("v4.0.0"):
             runtime_setup = AppRunV3Setup(self.context)
 
         if not runtime_setup:

--- a/recipes/appimage-builder/AppImageBuilder.yml
+++ b/recipes/appimage-builder/AppImageBuilder.yml
@@ -1,3 +1,7 @@
+# To build AppImageBuilder, specify explicit AppDir path other than current directory
+# e.g.
+# cd recipes/appimage-builder
+# APPIMAGE_BUILDER_VERSION=eaadff4 python ../../__main__.py --recipe AppImageBuilder.yml --appdir /tmp/appimage-builder
 version: 1
 script:
   # Remove any previous build

--- a/recipes/appimage-builder/AppImageBuilder.yml
+++ b/recipes/appimage-builder/AppImageBuilder.yml
@@ -50,7 +50,7 @@ AppDir:
     python3.8 -m pip install --ignore-installed --prefix=/usr --root="$TARGET_APPDIR"  install certifi
 
   runtime:
-    version: "continuous"
+    version: "v2.0.0"
     env:
       # Set python home
       # See https://docs.python.org/3/using/cmdline.html#envvar-PYTHONHOME

--- a/recipes/appimage-builder/AppImageBuilder.yml
+++ b/recipes/appimage-builder/AppImageBuilder.yml
@@ -15,14 +15,14 @@ AppDir:
     # Set the python executable as entry point
     exec: usr/bin/python3
     # Set the application main script path as argument. Use '$@' to forward CLI parameters
-    exec_args: "$APPDIR/usr/bin/appimage-builder $@"
+    exec_args: "$APPDIR/usr/local/bin/appimage-builder $@"
 
   apt:
     arch: amd64
     sources:
-      - sourceline: 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse'
-      - sourceline: 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ focal-updates main restricted universe multiverse'
-        key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3b4fe6acc0b21f32'
+      - sourceline: 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse'
+      - sourceline: 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-updates main restricted universe multiverse'
+        key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x871920D1991BC93C'
 
     include:
       - bash
@@ -34,7 +34,7 @@ AppDir:
       - fakeroot
       - libgdk-pixbuf2.0-dev
       - patchelf
-      - python3.8
+      - python3.10
       - squashfs-tools
       - strace
       - zsync
@@ -46,8 +46,8 @@ AppDir:
     ln -s bash $TARGET_APPDIR/bin/sh
 
     # install appimage-builder
-    python3.8 -m pip install --ignore-installed --prefix=/usr --root="$TARGET_APPDIR"  install ../../
-    python3.8 -m pip install --ignore-installed --prefix=/usr --root="$TARGET_APPDIR"  install certifi
+    python3.10 -m pip install --ignore-installed --prefix=/usr --root="$TARGET_APPDIR"  install ../../
+    python3.10 -m pip install --ignore-installed --prefix=/usr --root="$TARGET_APPDIR"  install certifi
 
   runtime:
     version: "v2.0.0"
@@ -57,9 +57,9 @@ AppDir:
       PYTHONHOME: '${APPDIR}/usr'
       # Path to the site-packages dir or other modules dirs
       # See https://docs.python.org/3/using/cmdline.html#envvar-PYTHONPATH
-      PYTHONPATH: '${APPDIR}/usr/lib/python3.8/site-packages'
+      PYTHONPATH: '${APPDIR}/usr/lib/python3.10/site-packages'
       # SSL Certificates are placed in a different location for every system therefore we ship our own copy
-      SSL_CERT_FILE: '${APPDIR}/usr/lib/python3.8/site-packages/certifi/cacert.pem'
+      SSL_CERT_FILE: '${APPDIR}/usr/lib/python3.10/site-packages/certifi/cacert.pem'
 
   test:
     fedora:
@@ -83,4 +83,4 @@ AppImage:
   update-information: 'gh-releases-zsync|AppImageCrafters|appimage-builder|latest|-*x86_64.AppImage.zsync'
   sign-key: None
   arch: x86_64
-
+  comp: gzip

--- a/recipes/bash-files/AppImageBuilder.yml
+++ b/recipes/bash-files/AppImageBuilder.yml
@@ -25,7 +25,7 @@ AppDir:
 
   runtime:
     arch: [ x86_64, i386 ]
-    version: continuous
+    
 
   test:
     debian:
@@ -48,3 +48,4 @@ AppDir:
 
 AppImage:
   arch: x86_64
+  comp: gzip

--- a/recipes/bash-pacman/AppImageBuilder.yml
+++ b/recipes/bash-pacman/AppImageBuilder.yml
@@ -54,3 +54,4 @@ AppImage:
   update-information: None
   sign-key: None
   arch: x86_64
+  comp: gzip

--- a/recipes/bash/AppImageBuilder.yml
+++ b/recipes/bash/AppImageBuilder.yml
@@ -44,7 +44,7 @@ AppDir:
 
   runtime:
     arch: [ x86_64, i386 ]
-    version: continuous
+    
 
   test:
     debian:
@@ -67,3 +67,4 @@ AppDir:
 
 AppImage:
   arch: x86_64
+  comp: gzip

--- a/recipes/gimp/AppImageBuilder.yml
+++ b/recipes/gimp/AppImageBuilder.yml
@@ -85,7 +85,7 @@ AppDir:
       - usr/share/doc/*/TODO.*
       - usr/include
   runtime:
-    version: continuous
+
     path_mappings:
       - /etc/gimp:$APPDIR/etc/gimp
       - /usr/lib/gimp:$APPDIR/usr/lib/gimp
@@ -117,3 +117,4 @@ AppDir:
 
 AppImage:
   arch: x86_64
+  comp: gzip

--- a/recipes/gnome-calculator/AppImageBuilder.yml
+++ b/recipes/gnome-calculator/AppImageBuilder.yml
@@ -27,9 +27,6 @@ AppDir:
       - ubuntu-mono
       - fonts-*-core
 
-  runtime:
-    version: "continuous"
-
   files:
     exclude:
       - usr/lib/x86_64-linux-gnu/gconv
@@ -61,3 +58,4 @@ AppImage:
   update-information: None
   sign-key: None
   arch: x86_64
+  comp: gzip

--- a/recipes/hello-world-gtk/AppImageBuilder.yml
+++ b/recipes/hello-world-gtk/AppImageBuilder.yml
@@ -31,9 +31,6 @@ AppDir:
       - ubuntu-mono
       - fonts-*-core
 
-  runtime:
-    version: "continuous"
-
   files:
     exclude:
       - usr/lib/x86_64-linux-gnu/gconv
@@ -67,3 +64,4 @@ AppImage:
   update-information: None
   sign-key: None
   arch: x86_64
+  comp: gzip

--- a/recipes/hello-world-qt5/AppImageBuilder.yml
+++ b/recipes/hello-world-qt5/AppImageBuilder.yml
@@ -65,3 +65,4 @@ AppDir:
 AppImage:
   arch: x86_64
   update-information: guess
+  comp: gzip

--- a/recipes/hello-world-qt6/AppImageBuilder.yml
+++ b/recipes/hello-world-qt6/AppImageBuilder.yml
@@ -107,3 +107,4 @@ AppDir:
 AppImage:
   arch: x86_64
   update-information: guess
+  comp: gzip

--- a/recipes/kcalc-files/AppImageBuilder.yml
+++ b/recipes/kcalc-files/AppImageBuilder.yml
@@ -158,8 +158,7 @@ AppDir:
       - usr/share/doc/*/changelog.*
       - usr/share/doc/*/NEWS.*
       - usr/share/doc/*/TODO.*
-  runtime:
-    version: v2.0.0-alpha
+  runtime: {}
   test:
     fedora-30:
       image: appimagecrafters/tests-env:fedora-30
@@ -179,3 +178,4 @@ AppDir:
 AppImage:
   arch: x86_64
   update-information: guess
+  comp: gzip

--- a/recipes/kcalc-nbc/AppImageBuilder.yml
+++ b/recipes/kcalc-nbc/AppImageBuilder.yml
@@ -37,9 +37,6 @@ AppDir:
       # exclude glibc for a smaller but non backward compatible bundles
       - opt/libc
 
-  runtime:
-    version: "continuous"
-
   test:
     debian:
       image: appimagecrafters/tests-env:debian-stable
@@ -62,3 +59,4 @@ AppImage:
   update-information: None
   sign-key: None
   arch: x86_64
+  comp: gzip

--- a/recipes/kcalc/AppImageBuilder.yml
+++ b/recipes/kcalc/AppImageBuilder.yml
@@ -41,8 +41,6 @@ AppDir:
       - usr/share/doc/*/NEWS.*
       - usr/share/doc/*/TODO.*
       - usr/share/metainfo/org.kde.kcalc.appdata.xml
-  runtime:
-    version: "continuous"
 
   test:
     debian:
@@ -66,3 +64,4 @@ AppImage:
   update-information: None
   sign-key: None
   arch: x86_64
+  comp: gzip

--- a/recipes/parole/AppImageBuilder.yml
+++ b/recipes/parole/AppImageBuilder.yml
@@ -59,3 +59,4 @@ AppDir:
 
 AppImage:
   arch: x86_64
+  comp: gzip

--- a/recipes/pyqt5/AppImageBuilder.yml
+++ b/recipes/pyqt5/AppImageBuilder.yml
@@ -36,7 +36,6 @@ AppDir:
     exclude: []
 
   runtime:
-    version: "continuous"
     env:
       PATH: '${APPDIR}/usr/bin:${PATH}'
       # Set python home
@@ -67,3 +66,4 @@ AppImage:
   update-information: 'gh-releases-zsync|AppImageCrafters|python-appimage-example|latest|python-appimage-*x86_64.AppImage.zsync'
   sign-key: None
   arch: x86_64
+  comp: gzip

--- a/recipes/python/AppImageBuilder.yml
+++ b/recipes/python/AppImageBuilder.yml
@@ -29,7 +29,6 @@ AppDir:
     exclude: [ ]
 
   runtime:
-    version: "continuous"
     env:
       EXPORTED_BINARIES: "$APPDIR/usr/bin/env"
 
@@ -55,3 +54,5 @@ AppImage:
   update-information: 'gh-releases-zsync|AppImageCrafters|python-appimage-example|latest|python-appimage-*x86_64.AppImage.zsync'
   sign-key: None
   arch: x86_64
+  comp: gzip
+  

--- a/recipes/qmlscene/AppImageBuilder.yml
+++ b/recipes/qmlscene/AppImageBuilder.yml
@@ -84,3 +84,5 @@ AppImage:
   update-information: None
   sign-key: None
   arch: x86_64
+  comp: gzip
+  

--- a/recipes/tkinter/AppImageBuilder.yml
+++ b/recipes/tkinter/AppImageBuilder.yml
@@ -70,3 +70,5 @@ AppImage:
   update-information: 'gh-releases-zsync|AppImageCrafters|python-appimage-example|latest|python-appimage-*x86_64.AppImage.zsync'
   sign-key: None
   arch: x86_64
+  comp: gzip
+  

--- a/recipes/vlc/AppImageBuilder.yml
+++ b/recipes/vlc/AppImageBuilder.yml
@@ -42,3 +42,4 @@ AppImage:
   arch: x86_64
   update-information: None
   sign-key: None
+  comp: gzip

--- a/recipes/wget/AppImageBuilder.yml
+++ b/recipes/wget/AppImageBuilder.yml
@@ -57,3 +57,4 @@ AppImage:
   update-information: None
   sign-key: None
   file_name: !ENV 'wget-${APP_VERSION}-${TARGET_ARCH}.AppImage'
+  comp: gzip

--- a/recipes/wine/AppImageBuilder.yml
+++ b/recipes/wine/AppImageBuilder.yml
@@ -57,4 +57,5 @@ AppImage:
   update-information: None
   sign-key: None
   arch: x86_64
+  comp: gzip
 


### PR DESCRIPTION
A range of fixes to allow appimage-builder to bootstrap an appimage of itself.

1. Updated all recipes to no longer use continuous as pydpkg library does not support non-numeric version numbers
2. Updated all recipes to add the new comp option
3. Updated the appimage-builder recipe to use Ubuntu 22.04 and Python3.10
5. Added instructions to the appimage-builder recipe for how to bootstrap build an appimage out of appimage-builder

This PR will allow the release of a new version of appimage-builder and creation of new .AppImage release file.
