### PR TITLE
Fix #347: No data compression

### DIFF
--- a/appimagebuilder/modules/prime/appimage_primer.py
+++ b/appimagebuilder/modules/prime/appimage_primer.py
@@ -90,7 +90,7 @@ class AppImagePrimer(BasePrimer):
         if self.config.comp() != "None":
             command += [ "-comp", self.config.comp()]
         else:
-            command += ["-no-compression"]
+            command += ["-noDataCompression"]
 
         self.logger.info("Creating squashfs from AppDir")
         self.logger.debug(" ".join(command))


### PR DESCRIPTION
Fixes #347 

mksquashfs has an option `-no-compression` [1] but it seems to have been released about 10 months ago [2] and not widely available, especially on older OS installations.

Switch to a more widely available `-noDatacompression` option instead. [3] [4]

1. https://www.mankier.com/1/mksquashfs
2. https://github.com/plougher/squashfs-tools/blame/1c791c5bdd2307458088e1f0821d9cefd14e0c96/README-4.6.1#L83
3. https://manpages.debian.org/jessie/squashfs-tools/mksquashfs.1.en.html
4. https://manpages.ubuntu.com/manpages/focal/man1/mksquashfs.1.html