### PR TITLE
make the compression field in the recipe optional

### DIFF
--- a/appimagebuilder/modules/prime/appimage_primer.py
+++ b/appimagebuilder/modules/prime/appimage_primer.py
@@ -87,8 +87,9 @@ class AppImagePrimer(BasePrimer):
         # I think this is better than hardcoding the supported compressions
         # If the team behind AppImageKit adds a new compression
         # we wouldn't need to update the code and release a new version just for a new compression method
-        if self.config.comp() != "None":
-            command += [ "-comp", self.config.comp()]
+        comp = self.config.comp() or "xz"
+        if comp != "None":
+            command += [ "-comp", comp]
         else:
             command += ["-no-compression"]
 

--- a/appimagebuilder/orchestrator.py
+++ b/appimagebuilder/orchestrator.py
@@ -178,7 +178,7 @@ class Orchestrator:
             app_info=app_info,
             update_string=recipe.AppImage["update-information"]() or "guess",
             runtime_arch=recipe.AppImage.arch(),
-            compression=recipe.AppImage.comp(),
+            compression=recipe.AppImage.comp() or "xz",
             sign_key=recipe.AppImage["sign-key"]() or None,
             file_name=recipe.AppImage["file_name"] or None,
         )

--- a/appimagebuilder/recipe/schema.py
+++ b/appimagebuilder/recipe/schema.py
@@ -93,7 +93,7 @@ class RecipeSchema:
         self.v1_appimage = Schema(
             {
                 "arch": str,
-                "comp": str,
+                Optional("comp"): str,
                 Optional("update-information"): str,
                 Optional("sign-key"): str,
                 Optional("file_name"): str,


### PR DESCRIPTION
make the compression field in the recipe optional and default to the `xz` compressor  

fixes https://github.com/AppImageCrafters/appimage-builder/issues/347 