### PR TITLE
fix: print libc version from embed strings

### DIFF
--- a/appimagebuilder/modules/setup/helpers/apprun_2_libc.py
+++ b/appimagebuilder/modules/setup/helpers/apprun_2_libc.py
@@ -71,7 +71,7 @@ class AppRun2LibC(BaseHelper):
         version_in_embed_strings = self.read_libc_version_from_embed_strings(libc_path)
         if version_in_embed_strings:
             logging.info(
-                "Taking libc version from embed strings: %s" % version_in_filename
+                "Taking libc version from embed strings: %s" % version_in_embed_strings
             )
             return version_in_embed_strings
 


### PR DESCRIPTION
This PR fixes printing the wrong libc version (always _none_).