### PR TITLE
Handle diversions when returned from dpk-query

### DIFF
--- a/appimagebuilder/modules/generate/package_managers/apt/file_package_resolver.py
+++ b/appimagebuilder/modules/generate/package_managers/apt/file_package_resolver.py
@@ -11,6 +11,8 @@
 #  all copies or substantial portions of the Software.
 import logging
 import subprocess
+import re
+import os
 
 from appimagebuilder.utils import shell
 
@@ -38,11 +40,19 @@ class FilePackageResolver:
         stdout_data = _proc.stdout.decode()
         return stdout_data
 
+    def _extract_package_names(self, pkg_names):
+        match = re.match(r"diversion by (.+?) (to|from)", pkg_names)
+        if match:
+            extracted_names = match.group(1).strip()
+            return extracted_names
+        else:
+            return pkg_names.strip()
+
     def _parse_dpkg_query_s_output(self, stdout_data):
         results = {}
         for line in stdout_data.splitlines():
             line_parts = line.split(sep=": ", maxsplit=1)
-            pkg_names = line_parts[0]
+            pkg_names = self._extract_package_names(line_parts[0])
             file_path = line_parts[1]
             for pkg_name in pkg_names.split(","):
                 pkg_name = pkg_name.strip()


### PR DESCRIPTION
The parser of the dpkg-query output should also handle diversions. When dpkg-query is run on Ubuntu, this is a possible output:

diversion by libc6 from: /lib64/ld-linux-x86-64.so.2
diversion by libc6 to: /lib64/ld-linux-x86-64.so.2.usr-is-merged

This commit parses the output, assumes libc6 is a dependency and adds it to the list.