### PR TITLE
Use the correct AppImage runtime continuous build URL

### DIFF
--- a/appimagebuilder/modules/prime/appimage_primer.py
+++ b/appimagebuilder/modules/prime/appimage_primer.py
@@ -99,7 +99,7 @@ class AppImagePrimer(BasePrimer):
 
     def _get_appimage_kit_runtime(self):
         url = (
-            "https://github.com/AppImage/AppImageKit/releases/download/continuous/runtime-%s"
+            "https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-%s"
             % self.bundle_main_arch
         )
         logging.info("Downloading: %s" % url)


### PR DESCRIPTION
The AppImage project has split the old AppImageKit repository into its component parts. Now the runtime is available via the `AppImage/type2-runtime` repository. This patch simply fixes the currently incorrect URL.